### PR TITLE
Content script now gets version from Manifest.json

### DIFF
--- a/chrome-extension/content_script.js
+++ b/chrome-extension/content_script.js
@@ -1,5 +1,12 @@
 var BASE_URL = "https://whaler-on-fleek.appspot.com"
-var WHALER_VERSION = "1.5" // TODO: Get this from the manifest?
+
+
+/**
+ * Gets version from manifest
+ * Available since Chrome 22
+ */
+var manifest = chrome.runtime.getManifest();
+var WHALER_VERSION = manifest.version;
 
 interstitial_url = null
 session_token = null


### PR DESCRIPTION
There was a TODO in the code asking for getting the version from Manifest.json. 
Since Chrome 22, it is possible by using:

``` javascript
chrome.runtime.getManifest();
```

Now, it will be dynamically loaded.
